### PR TITLE
Use Remix `defer` for test parity

### DIFF
--- a/modules/remix/app/routes/_index.tsx
+++ b/modules/remix/app/routes/_index.tsx
@@ -1,26 +1,35 @@
-import { json } from "@remix-run/node";
-import { useLoaderData } from "@remix-run/react";
+import { defer } from "@remix-run/node";
+import { Await, useLoaderData } from "@remix-run/react";
+import { Suspense } from "react";
 import { testData } from "testdata";
 
 export const loader = async () => {
-  return json(await testData());
+  return defer({ testData: testData() });
 };
 
 export default function App() {
   const data = useLoaderData<typeof loader>();
 
   return (
-    <table>
-      <tbody>
-        {data.map((entry) => (
-          <Entry key={entry.id} entry={entry} />
-        ))}
-      </tbody>
-    </table>
+    <Suspense fallback={<div>Loading...</div>}>
+      <Await resolve={data.testData}>
+        {(data) => (
+          <table>
+            <tbody>
+              {data.map((entry) => (
+                <Entry key={entry.id} entry={entry} />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Await>
+    </Suspense>
   );
 }
 
-function Entry(props: { entry: { id: string; name: string; asyncData?: () => Promise<string> } }) {
+function Entry(props: {
+  entry: { id: string; name: string; asyncData?: () => Promise<string> };
+}) {
   return (
     <tr>
       <td>{props.entry.id}</td>


### PR DESCRIPTION
Since your benchmark uses `async` for the other frameworks, this updates Remix to use `defer` and `Await` for test parity.

Using `defer` improved performance from 401 to 515 ops/sec on average.

>The table data is emulated as async and requires Suspense on react, solid and vue. On Next it is loaded in an async RSC component. On Remix it is loaded in a route loader function.