### PR TITLE
fix sveltekit (added Table component and create type)

### DIFF
--- a/modules/sveltekit/src/components/Entry.svelte
+++ b/modules/sveltekit/src/components/Entry.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  export let entry: { id: string; name: string };
+  import type { EntryData } from "$lib/type";
+
+  export let entry: EntryData
 </script>
 
 <tr>

--- a/modules/sveltekit/src/components/Table.svelte
+++ b/modules/sveltekit/src/components/Table.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import type { EntryData } from "$lib/type";
+  import Entry from './Entry.svelte'
+
+  export let entries: EntryData[]
+</script>
+
+<table>
+  {#each entries as entry}
+    <Entry {entry} />
+  {/each}
+</table>

--- a/modules/sveltekit/src/lib/type.ts
+++ b/modules/sveltekit/src/lib/type.ts
@@ -1,0 +1,2 @@
+import type { testData } from "testdata";
+export type EntryData = Awaited<ReturnType<typeof testData>>[0]

--- a/modules/sveltekit/src/routes/+page.svelte
+++ b/modules/sveltekit/src/routes/+page.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
-  import Entry from "../components/Entry.svelte";
+  import Table from "../components/Table.svelte";
 
-  export let data: any;
+  export let data;
 </script>
 
 <main>
-  <table>
-    {#each data.entries as entry}
-      <Entry {entry} />
-    {/each}
-  </table>
+  <Table entries={data.entries} />
 </main>


### PR DESCRIPTION
Hi!
I fixed some components in SvelteKit project.

In projects such as React and Solid, the Table was an independent component, yet in Sveltekit it was embedded in page.ts.