### PR TITLE
feat: added kitajs/html

### DIFF
--- a/modules/kita/.gitignore
+++ b/modules/kita/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/modules/kita/package.json
+++ b/modules/kita/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "kita-benchmark",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/entry-server.js",
+  "types": "dist/entry-server.d.ts",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@kitajs/html": "^4.1.0",
+    "tslib": "^2.6.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.5",
+    "typescript": "^5.4.5"
+  }
+}

--- a/modules/kita/src/App.tsx
+++ b/modules/kita/src/App.tsx
@@ -1,0 +1,34 @@
+import { Suspense } from '@kitajs/html/suspense.js';
+import { testData } from 'testdata';
+import Html from '@kitajs/html';
+
+export default function App(rid: number | string) {
+  return (
+    <Suspense rid={rid} fallback={''}>
+      <Table data={testData()} />
+    </Suspense>
+  );
+}
+
+async function Table({ data }: { data: ReturnType<typeof testData> }) {
+  return (
+    <table>
+      <tbody>
+        {(await data).map((entry) => (
+          <Entry entry={entry} />
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function Entry(props: {
+  entry: { id: string; name: string; asyncData?: () => Promise<string> };
+}) {
+  return (
+    <tr>
+      <td safe>{props.entry.id}</td>
+      <td safe>{props.entry.name}</td>
+    </tr>
+  );
+}

--- a/modules/kita/src/entry-server.tsx
+++ b/modules/kita/src/entry-server.tsx
@@ -1,0 +1,9 @@
+import { renderToStream } from '@kitajs/html/suspense.js';
+import { IncomingMessage, ServerResponse } from 'http';
+import App from './App.js';
+
+export function handler(_: IncomingMessage, res: ServerResponse) {
+  const stream = renderToStream(App);
+  res.setHeader('content-type', 'text/html');
+  stream.pipe(res);
+}

--- a/modules/kita/tsconfig.json
+++ b/modules/kita/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react",
+    "jsxFactory": "Html.createElement",
+    "jsxFragmentFactory": "Html.Fragment",
+    "outDir": "dist",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+
+    "types": [ "node"]
+  },
+  "include": ["src"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,18 @@
         "typescript": "^5.4.4"
       }
     },
+    "modules/kita": {
+      "name": "kita-benchmark",
+      "version": "0.0.0",
+      "dependencies": {
+        "@kitajs/html": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "devDependencies": {
+        "@types/node": "^20.10.5",
+        "typescript": "^5.4.5"
+      }
+    },
     "modules/mfng": {
       "name": "mfng-benchmark",
       "version": "0.0.0",
@@ -1525,6 +1537,20 @@
       "resolved": "https://registry.npmjs.org/@jspm/core/-/core-2.0.1.tgz",
       "integrity": "sha512-Lg3PnLp0QXpxwLIAuuJboLeRaIhrgJjeuh797QADg3xz8wGLugQOS5DpsE8A6i6Adgzf+bacllkKZG3J0tGfDw==",
       "dev": true
+    },
+    "node_modules/@kitajs/html": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@kitajs/html/-/html-4.1.0.tgz",
+      "integrity": "sha512-uB2HnIR7SYgLkIYdtEyTLc08MzukKh9BXRW6Qs3U9vRHG/LMeTpzuPHrkssfPjFAXHAoM4TukxV+rggJ57l5+A==",
+      "dependencies": {
+        "csstype": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/kitajs/html?sponsor=1"
+      }
     },
     "node_modules/@kwsites/file-exists": {
       "version": "1.1.1",
@@ -13199,6 +13225,10 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/kita-benchmark": {
+      "resolved": "modules/kita",
+      "link": true
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -20050,9 +20080,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
-      "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,10 @@ const handlers = [
     handler: await import("solid-benchmark").then((x) => x.buildHandler()),
   },
   {
+    name: "kita",
+    handler: await import("kita-benchmark").then((x) => x.handler),
+  },
+  {
     name: "react",
     handler: await import("react-benchmark").then((x) => x.buildHandler()),
   },


### PR DESCRIPTION
Feel free to ignore if you're not accepting new frameworks. 

This benchmark uses a empty string as a suspense fallback, just like react does.

```
┌─────────┬──────────────┬─────────┬──────────────┬─────────┬───────────┬─────────────┬──────────────────┐
│ (index) │ name         │ ops/sec │ average (ms) │ samples │ body (kb) │ duplication │ relative to kita │
├─────────┼──────────────┼─────────┼──────────────┼─────────┼───────────┼─────────────┼──────────────────┤
│ 0       │ 'kita'       │ 2844    │ '0.352'      │ 28447   │ '97.34'   │ 'x1.00'     │ ''               │
│ 1       │ 'react'      │ 885     │ '1.130'      │ 8851    │ '97.28'   │ 'x1.00'     │ '3.21 x slower'  │
│ 2       │ 'sveltekit'  │ 628     │ '1.591'      │ 6287    │ '184.46'  │ 'x2.00'     │ '4.53 x slower'  │
│ 3       │ 'solid'      │ 612     │ '1.632'      │ 6127    │ '215.93'  │ 'x2.00'     │ '4.65 x slower'  │
│ 4       │ 'remix'      │ 445     │ '2.246'      │ 4452    │ '189.10'  │ 'x2.00'     │ '6.39 x slower'  │
│ 5       │ 'vue'        │ 246     │ '4.054'      │ 2467    │ '96.72'   │ 'x1.00'     │ '11.56 x slower' │
│ 6       │ 'nuxt'       │ 202     │ '4.929'      │ 2029    │ '97.57'   │ 'x1.00'     │ '14.08 x slower' │
│ 7       │ 'next-pages' │ 94      │ '10.619'     │ 942     │ '187.67'  │ 'x2.00'     │ '30.26 x slower' │
│ 8       │ 'mfng'       │ 69      │ '14.368'     │ 697     │ '317.31'  │ 'x2.50'     │ '41.22 x slower' │
│ 9       │ 'next'       │ 52      │ '19.161'     │ 522     │ '284.64'  │ 'x2.00'     │ '54.69 x slower' │
└─────────┴──────────────┴─────────┴──────────────┴─────────┴───────────┴─────────────┴──────────────────┘
```