### PR TITLE
Add hono

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+	"singleQuote": false,
+	"semi": true
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,0 @@
-{
-	"singleQuote": false,
-	"semi": true
-}

--- a/modules/hono/.gitignore
+++ b/modules/hono/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/modules/hono/package.json
+++ b/modules/hono/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "hono-benchmark",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "vite build --ssr src/entry-server.tsx --outDir dist"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.5",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.10"
+  },
+  "types": "dist/entry-server.d.ts",
+  "main": "dist/entry-server.js",
+  "dependencies": {
+    "@hono/node-server": "^1.9.1",
+    "hono": "^4.2.3"
+  }
+}

--- a/modules/hono/src/App.tsx
+++ b/modules/hono/src/App.tsx
@@ -5,11 +5,11 @@ function App() {
 }
 
 async function Table({ data }: { data: ReturnType<typeof testData> }) {
-  const tdata = await data
+  const entries = await data
   return (
     <table>
       <tbody>
-        {tdata.map((entry) => (
+        {entries.map((entry) => (
           <Entry entry={entry} />
         ))}
       </tbody>

--- a/modules/hono/src/App.tsx
+++ b/modules/hono/src/App.tsx
@@ -1,7 +1,12 @@
 import { testData } from "testdata";
+import { Suspense } from "hono/jsx";
 
 function App() {
-  return <Table data={testData()} />;
+  return (
+    <Suspense fallback={"loading..."}>
+      <Table data={testData()} />
+    </Suspense>
+  );
 }
 
 async function Table({ data }: { data: ReturnType<typeof testData> }) {

--- a/modules/hono/src/App.tsx
+++ b/modules/hono/src/App.tsx
@@ -1,0 +1,29 @@
+import { testData } from 'testdata'
+
+function App() {
+  return <Table data={testData()} />
+}
+
+async function Table({ data }: { data: ReturnType<typeof testData> }) {
+  const tdata = await data
+  return (
+    <table>
+      <tbody>
+        {tdata.map((entry) => (
+          <Entry entry={entry} />
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+function Entry(props: { entry: { id: string; name: string } }) {
+  return (
+    <tr>
+      <td>{props.entry.id}</td>
+      <td>{props.entry.name}</td>
+    </tr>
+  )
+}
+
+export default App

--- a/modules/hono/src/App.tsx
+++ b/modules/hono/src/App.tsx
@@ -1,11 +1,11 @@
-import { testData } from 'testdata'
+import { testData } from "testdata";
 
 function App() {
-  return <Table data={testData()} />
+  return <Table data={testData()} />;
 }
 
 async function Table({ data }: { data: ReturnType<typeof testData> }) {
-  const entries = await data
+  const entries = await data;
   return (
     <table>
       <tbody>
@@ -14,7 +14,7 @@ async function Table({ data }: { data: ReturnType<typeof testData> }) {
         ))}
       </tbody>
     </table>
-  )
+  );
 }
 
 function Entry(props: { entry: { id: string; name: string } }) {
@@ -23,7 +23,7 @@ function Entry(props: { entry: { id: string; name: string } }) {
       <td>{props.entry.id}</td>
       <td>{props.entry.name}</td>
     </tr>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/modules/hono/src/entry-server.tsx
+++ b/modules/hono/src/entry-server.tsx
@@ -1,20 +1,29 @@
 import App from "./App";
 import { Hono } from "hono";
+import { renderToReadableStream } from "hono/jsx/streaming";
 import { getRequestListener } from "@hono/node-server";
 
 const app = new Hono();
 
 app.get("/", async (c) => {
-  return c.html(
-    <html lang="en">
-      <head>
-        <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-      </head>
-      <body>
-        <App />
-      </body>
-    </html>
+  return c.body(
+    renderToReadableStream(
+      <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+        </head>
+        <body>
+          <App />
+        </body>
+      </html>
+    ),
+    {
+      headers: {
+        "Content-Type": "text/html; charset=UTF-8",
+        "Transfer-Encoding": "chunked",
+      },
+    }
   );
 });
 

--- a/modules/hono/src/entry-server.tsx
+++ b/modules/hono/src/entry-server.tsx
@@ -1,0 +1,12 @@
+import App from './App'
+import { Hono } from 'hono'
+import { getRequestListener } from '@hono/node-server'
+
+const app = new Hono()
+app.get('*', (c) => {
+  return c.html(<App />)
+})
+
+export async function buildHandler() {
+  return getRequestListener(app.fetch)
+}

--- a/modules/hono/src/entry-server.tsx
+++ b/modules/hono/src/entry-server.tsx
@@ -1,10 +1,10 @@
-import App from './App'
-import { Hono } from 'hono'
-import { getRequestListener } from '@hono/node-server'
+import App from "./App";
+import { Hono } from "hono";
+import { getRequestListener } from "@hono/node-server";
 
-const app = new Hono()
+const app = new Hono();
 
-app.get('/', async (c) => {
+app.get("/", async (c) => {
   return c.html(
     <html lang="en">
       <head>
@@ -15,9 +15,9 @@ app.get('/', async (c) => {
         <App />
       </body>
     </html>
-  )
-})
+  );
+});
 
 export async function buildHandler() {
-  return getRequestListener(app.fetch)
+  return getRequestListener(app.fetch);
 }

--- a/modules/hono/src/entry-server.tsx
+++ b/modules/hono/src/entry-server.tsx
@@ -3,8 +3,19 @@ import { Hono } from 'hono'
 import { getRequestListener } from '@hono/node-server'
 
 const app = new Hono()
-app.get('*', (c) => {
-  return c.html(<App />)
+
+app.get('/', async (c) => {
+  return c.html(
+    <html lang="en">
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </head>
+      <body>
+        <App />
+      </body>
+    </html>
+  )
 })
 
 export async function buildHandler() {

--- a/modules/hono/tsconfig.json
+++ b/modules/hono/tsconfig.json
@@ -1,27 +1,13 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "lib": [
-      "ES2020",
-      "DOM",
-      "DOM.Iterable"
-    ],
-    "module": "ESNext",
+    "target": "ES2022",
+    "module": "ES2022",
     "skipLibCheck": true,
-    /* Bundler mode */
     "moduleResolution": "Bundler",
-    "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx",
-    /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
     "types": [
       "node"
     ]

--- a/modules/hono/tsconfig.json
+++ b/modules/hono/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": [
+      "ES2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    /* Bundler mode */
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx",
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,19 @@
         "typescript": "^5.4.4"
       }
     },
+    "modules/hono": {
+      "name": "hono-benchmark",
+      "version": "0.0.0",
+      "dependencies": {
+        "@hono/node-server": "^1.9.1",
+        "hono": "^4.2.3"
+      },
+      "devDependencies": {
+        "@types/node": "^20.10.5",
+        "typescript": "^5.3.3",
+        "vite": "^5.0.10"
+      }
+    },
     "modules/mfng": {
       "name": "mfng-benchmark",
       "version": "0.0.0",
@@ -1330,6 +1343,14 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
       "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==",
       "peer": true
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.9.1.tgz",
+      "integrity": "sha512-XBru0xbtRlTZJyAiFJLn7XDKbCVXBaRhVQAQhB9TwND2gwj8jf9SDWIj/7VxVtNAjURJf7Ofcz58DRA6DPYiWA==",
+      "engines": {
+        "node": ">=18.14.1"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -11939,6 +11960,18 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hono": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.2.3.tgz",
+      "integrity": "sha512-yZDnPOp/XzjIB7KUWaOxwLSywnhxMvAKth8hfKhWQiWXeZhBfC6GlFnEst/FOOgn7rSWjShhQPS89PLEuHxq3Q==",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/hono-benchmark": {
+      "resolved": "modules/hono",
+      "link": true
     },
     "node_modules/hookable": {
       "version": "5.5.3",

--- a/src/index.js
+++ b/src/index.js
@@ -1,84 +1,88 @@
-import { Bench } from "tinybench";
-import { IncomingMessage, ServerResponse } from "./http.js";
-import { buildRemixHandler } from "./remix.js";
-import { buildNextHandler } from "./next.js";
-import { buildNuxtHandler } from "./nuxt.js";
-import { buildSveltekitHandler } from "./svelte.js";
-import http from "node:http";
-import { getDuplicationFactor, logResultsTable } from "./result-format.js";
+import { Bench } from 'tinybench'
+import { IncomingMessage, ServerResponse } from './http.js'
+import { buildRemixHandler } from './remix.js'
+import { buildNextHandler } from './next.js'
+import { buildNuxtHandler } from './nuxt.js'
+import { buildSveltekitHandler } from './svelte.js'
+import http from 'node:http'
+import { getDuplicationFactor, logResultsTable } from './result-format.js'
 
 export async function run(handler, collect = false) {
-  const request = new IncomingMessage();
-  const response = new ServerResponse(request, collect);
+  const request = new IncomingMessage()
+  const response = new ServerResponse(request, collect)
 
-  handler(request, response);
+  handler(request, response)
 
-  await response.await;
-  return response;
+  await response.await
+  return response
 }
 
-const bench = new Bench({ time: 15_000 });
+const bench = new Bench({ time: 15_000 })
 
 const handlers = [
   {
-    name: "solid",
-    handler: await import("solid-benchmark").then((x) => x.buildHandler()),
+    name: 'solid',
+    handler: await import('solid-benchmark').then((x) => x.buildHandler())
   },
   {
-    name: "react",
-    handler: await import("react-benchmark").then((x) => x.buildHandler()),
+    name: 'react',
+    handler: await import('react-benchmark').then((x) => x.buildHandler())
   },
   {
-    name: "vue",
-    handler: await import("vue-benchmark").then((x) => x.buildHandler()),
+    name: 'vue',
+    handler: await import('vue-benchmark').then((x) => x.buildHandler())
   },
   {
-    name: "mfng",
-    handler: await import("mfng-benchmark").then((x) => x.buildHandler()),
+    name: 'mfng',
+    handler: await import('mfng-benchmark').then((x) => x.buildHandler())
   },
-  { name: "remix", handler: await buildRemixHandler() },
-  { name: "next", handler: await buildNextHandler() },
-  { name: "nuxt", handler: await buildNuxtHandler() },
-  { name: "sveltekit", handler: await buildSveltekitHandler() },
-];
+  {
+    name: 'hono',
+    handler: await import('hono-benchmark').then((x) => x.buildHandler())
+  },
+  { name: 'remix', handler: await buildRemixHandler() },
+  { name: 'next', handler: await buildNextHandler() },
+  { name: 'nuxt', handler: await buildNuxtHandler() },
+  { name: 'sveltekit', handler: await buildSveltekitHandler() }
+]
 
 for (let handler of handlers) {
   bench.add(handler.name, async () => {
-    await run(handler.handler);
-  });
+    await run(handler.handler)
+  })
 }
 
-await bench.warmup();
-await bench.run();
+await bench.warmup()
+await bench.run()
 
 for (let handler of handlers) {
-  let response = await run(handler.handler, true);
+  let response = await run(handler.handler, true)
 
   bench.getTask(handler.name).setResult({
     bodyLength: response.length,
-    duplicationFactor: getDuplicationFactor(response.body),
-  });
+    duplicationFactor: getDuplicationFactor(response.body)
+  })
 }
 
-logResultsTable(bench);
+logResultsTable(bench)
 
-console.log();
-console.log("Check out the actual render results:");
+console.log()
+console.log('Check out the actual render results:')
 
 for (let handler of handlers) {
-  console.log(handler.name, `http://localhost:8080/${handler.name}`);
+  console.log(handler.name, `http://localhost:8080/${handler.name}`)
 }
 
 http
   .createServer(async function (req, res) {
-    const handler = handlers.find((x) => "/" + x.name == req.url);
+    const handler = handlers.find((x) => '/' + x.name == req.url)
 
     if (handler) {
-      req.url = "/";
-      handler.handler(req, res);
+      req.url = '/'
+      handler.handler(req, res)
     } else {
-      res.writeHead(404);
-      res.end();
+      res.writeHead(404)
+      res.end()
     }
   })
-  .listen(8080);
+  .listen(8080)

--- a/src/index.js
+++ b/src/index.js
@@ -1,88 +1,88 @@
-import { Bench } from 'tinybench'
-import { IncomingMessage, ServerResponse } from './http.js'
-import { buildRemixHandler } from './remix.js'
-import { buildNextHandler } from './next.js'
-import { buildNuxtHandler } from './nuxt.js'
-import { buildSveltekitHandler } from './svelte.js'
-import http from 'node:http'
-import { getDuplicationFactor, logResultsTable } from './result-format.js'
+import { Bench } from "tinybench";
+import { IncomingMessage, ServerResponse } from "./http.js";
+import { buildRemixHandler } from "./remix.js";
+import { buildNextHandler } from "./next.js";
+import { buildNuxtHandler } from "./nuxt.js";
+import { buildSveltekitHandler } from "./svelte.js";
+import http from "node:http";
+import { getDuplicationFactor, logResultsTable } from "./result-format.js";
 
 export async function run(handler, collect = false) {
-  const request = new IncomingMessage()
-  const response = new ServerResponse(request, collect)
+  const request = new IncomingMessage();
+  const response = new ServerResponse(request, collect);
 
-  handler(request, response)
+  handler(request, response);
 
-  await response.await
-  return response
+  await response.await;
+  return response;
 }
 
-const bench = new Bench({ time: 15_000 })
+const bench = new Bench({ time: 15_000 });
 
 const handlers = [
   {
-    name: 'solid',
-    handler: await import('solid-benchmark').then((x) => x.buildHandler())
+    name: "solid",
+    handler: await import("solid-benchmark").then((x) => x.buildHandler()),
   },
   {
-    name: 'react',
-    handler: await import('react-benchmark').then((x) => x.buildHandler())
+    name: "react",
+    handler: await import("react-benchmark").then((x) => x.buildHandler()),
   },
   {
-    name: 'vue',
-    handler: await import('vue-benchmark').then((x) => x.buildHandler())
+    name: "vue",
+    handler: await import("vue-benchmark").then((x) => x.buildHandler()),
   },
   {
-    name: 'mfng',
-    handler: await import('mfng-benchmark').then((x) => x.buildHandler())
+    name: "mfng",
+    handler: await import("mfng-benchmark").then((x) => x.buildHandler()),
   },
   {
-    name: 'hono',
-    handler: await import('hono-benchmark').then((x) => x.buildHandler())
+    name: "hono",
+    handler: await import("hono-benchmark").then((x) => x.buildHandler()),
   },
-  { name: 'remix', handler: await buildRemixHandler() },
-  { name: 'next', handler: await buildNextHandler() },
-  { name: 'nuxt', handler: await buildNuxtHandler() },
-  { name: 'sveltekit', handler: await buildSveltekitHandler() }
-]
+  { name: "remix", handler: await buildRemixHandler() },
+  { name: "next", handler: await buildNextHandler() },
+  { name: "nuxt", handler: await buildNuxtHandler() },
+  { name: "sveltekit", handler: await buildSveltekitHandler() },
+];
 
 for (let handler of handlers) {
   bench.add(handler.name, async () => {
-    await run(handler.handler)
-  })
+    await run(handler.handler);
+  });
 }
 
-await bench.warmup()
-await bench.run()
+await bench.warmup();
+await bench.run();
 
 for (let handler of handlers) {
-  let response = await run(handler.handler, true)
+  let response = await run(handler.handler, true);
 
   bench.getTask(handler.name).setResult({
     bodyLength: response.length,
-    duplicationFactor: getDuplicationFactor(response.body)
-  })
+    duplicationFactor: getDuplicationFactor(response.body),
+  });
 }
 
-logResultsTable(bench)
+logResultsTable(bench);
 
-console.log()
-console.log('Check out the actual render results:')
+console.log();
+console.log("Check out the actual render results:");
 
 for (let handler of handlers) {
-  console.log(handler.name, `http://localhost:8080/${handler.name}`)
+  console.log(handler.name, `http://localhost:8080/${handler.name}`);
 }
 
 http
   .createServer(async function (req, res) {
-    const handler = handlers.find((x) => '/' + x.name == req.url)
+    const handler = handlers.find((x) => "/" + x.name == req.url);
 
     if (handler) {
-      req.url = '/'
-      handler.handler(req, res)
+      req.url = "/";
+      handler.handler(req, res);
     } else {
-      res.writeHead(404)
-      res.end()
+      res.writeHead(404);
+      res.end();
     }
   })
-  .listen(8080)
+  .listen(8080);


### PR DESCRIPTION
In this PR, I'll add a script with [Hono framework](https://hono.dev/). It uses JSX provided by Hono, and it works as a [real application](https://github.com/eknkc/ssr-benchmark/compare/master...yusukebe:ssr-benchmark:add-hono#diff-9119c5e784d9a68b31eb52b1b3caa4ae4a5f788a24296e45b0b2ede0f5706db4R7-R19), not only as "template rendering".

The result:

![CleanShot 2024-04-12 at 00 14 16@2x](https://github.com/eknkc/ssr-benchmark/assets/10682/5d9a6d58-5f7d-4a86-af8d-409bf8486867)

Hono is a bit different from frameworks such as Next.js and Remix and not as major as them, so it may not be listed here. I'll leave it to you.