### PR TITLE
perf(nuxt): use shallow ref + separate data chunk

### DIFF
--- a/modules/nuxt/components/Table.vue
+++ b/modules/nuxt/components/Table.vue
@@ -1,7 +1,5 @@
 <script setup>
-import { testData } from "testdata";
-
-const { data } = await useAsyncData(testData);
+const { data } = await useAsyncData(() => import('testdata').then(r => r.testData()), { deep: false });
 </script>
 
 <template>


### PR DESCRIPTION
This does two things:

1. it loads `testdata` as an async chunk. As you've switched to using `useAsyncData`, we can benefit from a built-in optimisation that we do not need to rerun or load this function/data on the client
2. it uses a non-deeply reactive data structure for storing the data (a regression when the benchmark switched to `useAsyncData`). This will be the default in Nuxt v4.
